### PR TITLE
Fix: wrong assumption on routeName

### DIFF
--- a/lib/splashscreen.dart
+++ b/lib/splashscreen.dart
@@ -80,9 +80,9 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    if (!(widget.routeName != null &&
+    if (widget.routeName != null &&
         widget.routeName is String &&
-        "${widget.routeName[0]}" == "/"))
+        "${widget.routeName[0]}" != "/")
       throw new ArgumentError(
           "widget.routeName must be a String beginning with forward slash (/)");
     if (widget.navigateAfterFuture == null) {


### PR DESCRIPTION
Current assumption always validates to true. I guess the initial intention was to throw an error if a route does not start with a forward slash. 
fixes #50 