### PR TITLE
Add factory constructors to distinguish between timer based or network based instantiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 
 .packages
 .pub/
+*.iml
 
 build/
 ios/.generated/
 ios/Flutter/Generated.xcconfig
 ios/Runner/GeneratedPluginRegistrant.*
+!/splashscreen.iml

--- a/lib/splashscreen.dart
+++ b/lib/splashscreen.dart
@@ -1,7 +1,8 @@
 library splashscreen;
 
-import 'dart:core';
 import 'dart:async';
+import 'dart:core';
+
 import 'package:flutter/material.dart';
 
 class SplashScreen extends StatefulWidget {
@@ -52,18 +53,21 @@ class SplashScreen extends StatefulWidget {
 
   /// expects a function that returns a future, when this future is returned it will navigate
   final Future<dynamic> navigateAfterFuture;
+
+  /// Use one of the provided factory constructors instead of.
+  @protected
   SplashScreen({
     this.loaderColor,
     this.navigateAfterFuture,
-    @required this.seconds,
+    this.seconds,
     this.photoSize,
     this.pageRoute,
     this.onClick,
     this.navigateAfterSeconds,
     this.title = const Text(''),
     this.backgroundColor = Colors.white,
-    this.styleTextUnderTheLoader = const TextStyle(
-        fontSize: 18.0, fontWeight: FontWeight.bold, color: Colors.black),
+    this.styleTextUnderTheLoader =
+        const TextStyle(fontSize: 18.0, fontWeight: FontWeight.bold, color: Colors.black),
     this.image,
     this.loadingText = const Text(""),
     this.imageBackground,
@@ -71,6 +75,74 @@ class SplashScreen extends StatefulWidget {
     this.useLoader = true,
     this.routeName,
   });
+
+  factory SplashScreen.timer(
+          {@required int seconds,
+          Color loaderColor,
+          Color backgroundColor,
+          double photoSize,
+          Text loadingText,
+          Image image,
+          Route pageRoute,
+          dynamic onClick,
+          dynamic navigateAfterSeconds,
+          Text title,
+          TextStyle styleTextUnderTheLoader,
+          ImageProvider imageBackground,
+          Gradient gradientBackground,
+          bool useLoader,
+          String routeName}) =>
+      SplashScreen(
+        loaderColor: loaderColor,
+        seconds: seconds,
+        photoSize: photoSize,
+        loadingText: loadingText,
+        backgroundColor: backgroundColor,
+        image: image,
+        pageRoute: pageRoute,
+        onClick: onClick,
+        navigateAfterSeconds: navigateAfterSeconds,
+        title: title,
+        styleTextUnderTheLoader: styleTextUnderTheLoader,
+        imageBackground: imageBackground,
+        gradientBackground: gradientBackground,
+        useLoader: useLoader,
+        routeName: routeName,
+      );
+
+  factory SplashScreen.network(
+          {@required Future<dynamic> navigateAfterFuture,
+          Color loaderColor,
+          Color backgroundColor,
+          double photoSize,
+          Text loadingText,
+          Image image,
+          Route pageRoute,
+          dynamic onClick,
+          dynamic navigateAfterSeconds,
+          Text title,
+          TextStyle styleTextUnderTheLoader,
+          ImageProvider imageBackground,
+          Gradient gradientBackground,
+          bool useLoader,
+          String routeName}) =>
+      SplashScreen(
+        loaderColor: loaderColor,
+        navigateAfterFuture: navigateAfterFuture,
+        photoSize: photoSize,
+        loadingText: loadingText,
+        backgroundColor: backgroundColor,
+        image: image,
+        pageRoute: pageRoute,
+        onClick: onClick,
+        navigateAfterSeconds: navigateAfterSeconds,
+        title: title,
+        styleTextUnderTheLoader: styleTextUnderTheLoader,
+        imageBackground: imageBackground,
+        gradientBackground: gradientBackground,
+        useLoader: useLoader,
+        routeName: routeName,
+      );
 
   @override
   _SplashScreenState createState() => _SplashScreenState();
@@ -80,30 +152,24 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    if (widget.routeName != null &&
-        widget.routeName is String &&
-        "${widget.routeName[0]}" != "/")
-      throw new ArgumentError(
-          "widget.routeName must be a String beginning with forward slash (/)");
+    if (widget.routeName != null && widget.routeName is String && "${widget.routeName[0]}" != "/") {
+      throw new ArgumentError("widget.routeName must be a String beginning with forward slash (/)");
+    }
     if (widget.navigateAfterFuture == null) {
       Timer(Duration(seconds: widget.seconds), () {
         if (widget.navigateAfterSeconds is String) {
           // It's fairly safe to assume this is using the in-built material
           // named route component
-          Navigator.of(context)
-              .pushReplacementNamed(widget.navigateAfterSeconds);
+          Navigator.of(context).pushReplacementNamed(widget.navigateAfterSeconds);
         } else if (widget.navigateAfterSeconds is Widget) {
           Navigator.of(context).pushReplacement(widget.pageRoute != null
               ? widget.pageRoute
               : new MaterialPageRoute(
-                  settings: widget.routeName != null
-                      ? RouteSettings(name: "${widget.routeName}")
-                      : null,
-                  builder: (BuildContext context) =>
-                      widget.navigateAfterSeconds));
+                  settings:
+                      widget.routeName != null ? RouteSettings(name: "${widget.routeName}") : null,
+                  builder: (BuildContext context) => widget.navigateAfterSeconds));
         } else {
-          throw new ArgumentError(
-              'widget.navigateAfterSeconds must either be a String or Widget');
+          throw new ArgumentError('widget.navigateAfterSeconds must either be a String or Widget');
         }
       });
     } else {
@@ -116,13 +182,11 @@ class _SplashScreenState extends State<SplashScreen> {
           Navigator.of(context).pushReplacement(widget.pageRoute != null
               ? widget.pageRoute
               : new MaterialPageRoute(
-                  settings: widget.routeName != null
-                      ? RouteSettings(name: "${widget.routeName}")
-                      : null,
+                  settings:
+                      widget.routeName != null ? RouteSettings(name: "${widget.routeName}") : null,
                   builder: (BuildContext context) => navigateTo));
         } else {
-          throw new ArgumentError(
-              'widget.navigateAfterFuture must either be a String or Widget');
+          throw new ArgumentError('widget.navigateAfterFuture must either be a String or Widget');
         }
       });
     }
@@ -180,8 +244,7 @@ class _SplashScreenState extends State<SplashScreen> {
                       !widget.useLoader
                           ? Container()
                           : CircularProgressIndicator(
-                              valueColor: new AlwaysStoppedAnimation<Color>(
-                                  widget.loaderColor),
+                              valueColor: new AlwaysStoppedAnimation<Color>(widget.loaderColor),
                             ),
                       Padding(
                         padding: const EdgeInsets.only(top: 20.0),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,77 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "2.5.0-nullsafety.1"
-=======
-    version: "2.5.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "2.1.0-nullsafety.1"
-=======
-    version: "2.1.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.1.0-nullsafety.3"
-=======
-    version: "1.1.0-nullsafety.2"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.2.0-nullsafety.1"
-=======
-    version: "1.2.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.1.0-nullsafety.1"
-=======
-    version: "1.1.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.15.0-nullsafety.3"
-=======
-    version: "1.15.0-nullsafety.2"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.2.0-nullsafety.1"
-=======
-    version: "1.1.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   flutter:
     dependency: "direct main"
     description: flutter
@@ -94,33 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "0.12.10-nullsafety.1"
-=======
-    version: "0.12.10-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.3.0-nullsafety.3"
-=======
-    version: "1.3.0-nullsafety.2"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.8.0-nullsafety.1"
-=======
-    version: "1.8.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   sky_engine:
     dependency: transitive
     description: flutter
@@ -132,89 +92,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.8.0-nullsafety.2"
-=======
-    version: "1.8.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.10.0-nullsafety.1"
-=======
-    version: "1.10.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "2.1.0-nullsafety.1"
-=======
-    version: "2.1.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.1.0-nullsafety.1"
-=======
-    version: "1.1.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.2.0-nullsafety.1"
-=======
-    version: "1.2.0-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "0.2.19-nullsafety.2"
-=======
-    version: "0.2.19-nullsafety"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "1.3.0-nullsafety.3"
-=======
-    version: "1.3.0-nullsafety.2"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-<<<<<<< HEAD
     version: "2.1.0-nullsafety.3"
 sdks:
   dart: ">=2.10.0-110 <2.11.0"
-=======
-    version: "2.1.0-nullsafety.2"
-sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
->>>>>>> 23732c810048acb81fd617da143e99d23f4a780e


### PR DESCRIPTION
The current `SplashScreen` constructor requires the `second` property although it is not needed when the SplashScreen uses the future based navigation.  Hence, I've removed the `@required` annotation and created two factory constructors which makes the API a bit more self explaining. 


* add factory constructors to either require seconds for timer based instantiation or the navigateFuture for network call based instantiation
* remove required annotation for seconds on existent constructor
* make existent constructor protected for backward compatibility and smooth migration

* fix broke `pubspec.lock.yml`
* exclude Idea's `*.iml` files from being pushed to git