### PR TITLE
doc: dependency version + package version added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [Splash Screen](https://pub.dev/packages/splashscreen)
-
+<a href="https://pub.dev/packages/splashscreen"><img src="https://img.shields.io/pub/v/splashscreen?logo=dart" alt="pub.dev"></a>
 * A splashscreen package to be used for an intro for any flutter application easily with a lot of customization
 
 ## Currently Supported by awesome [DPLYR](https://dplyr.dev)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use this package :
   dependencies:
     flutter:
       sdk: flutter
-    splashscreen:
+    splashscreen: ^1.3.5
 ```
 
 ### How to use


### PR DESCRIPTION
This  PR is to make the package version visible on the main documentation page.
In the setup of the package, the version was missing, and also the version is added in this PR.
Closes #68 